### PR TITLE
feat(ui): utilisation d’un `.` pour séparateur de dates

### DIFF
--- a/src/components/Indicateurs/DernierePiaf.js
+++ b/src/components/Indicateurs/DernierePiaf.js
@@ -23,7 +23,7 @@ const DernierePiaf = ({ nbSemaines, date, ...props }) => {
     <Container {...commonProps} color="white" bg={ok ? "green" : "orange"}>
       <Text fontSize={8}>{nbSemaines}</Text>
       <Text>semaines depuis la dernière PIAF</Text>
-      <Text fontSize={4}>{`(${date})`}</Text>
+      <Text fontSize={4}>{`(${date.toString().replace(/\//gi, ".")})`}</Text>
     </Container>
   );
 };

--- a/src/components/Indicateurs/ProchainePiaf.js
+++ b/src/components/Indicateurs/ProchainePiaf.js
@@ -12,7 +12,7 @@ const ProchainePiaf = ({ date, ...props }) => {
       textAlign="center"
     >
       <Text fontSize={8}>
-        {date.replace(`/${new Date().getFullYear()}`, "")}
+        {date.replace(`/${new Date().getFullYear()}`, "").replace(/\//gi, ".")}
       </Text>
       <Text>pour votre prochaine PIAF</Text>
       <Text fontSize={4}>


### PR DESCRIPTION
de manière à ne pas confondre avec « effectué / attendu »

closes #24